### PR TITLE
Add airgap option to TRANSFER commands

### DIFF
--- a/src/components/StepList.tsx
+++ b/src/components/StepList.tsx
@@ -75,6 +75,9 @@ function getListItemText(step: Step) {
   if (step.touchtip) {
     secondaryArray.push("Touch tip: " + step.touchtip)
   }
+  if (step.airgap) {
+    secondaryArray.push("Airgap: " + step.airgap + "µL")
+  }
   if (step.blowout) {
     secondaryArray.push("Blowout: " + step.blowout)
   }

--- a/src/components/dialogs/StepEditDialog.tsx
+++ b/src/components/dialogs/StepEditDialog.tsx
@@ -1,7 +1,7 @@
 import React, {FC, useEffect} from 'react';
 import Button from '@material-ui/core/Button';
 import Dialog from '@material-ui/core/Dialog';
-import {Step, Labware, Well} from "../../datatypes";
+import {Step, stepTypeHas, Labware, Well} from "../../datatypes";
 import {TextField, Checkbox, FormControlLabel, FormControl, Select, InputLabel, MenuItem, Grid, withStyles, Theme, Tooltip} from "@material-ui/core";
 import {DialogActions, DialogContent, DialogTitle} from "./shared/DialogStyledComponents";
 import {WellSelect} from "./shared/WellSelect";
@@ -37,6 +37,7 @@ export const StepEditDialog: FC<StepDialogProps> = ({initialStep, handleClose, h
     setLocation(initialStep?.location)
     setVolume(initialStep?.volume ?? 0)
     setTouchTip(initialStep?.touchtip ?? true)
+    setAirgap(initialStep?.airgap ?? 0)
     setBlowout(initialStep?.blowout ?? false)
     setBlowoutLocation(initialStep?.blowoutLocation ?? "trash")
     setTimes(initialStep?.times ?? 0)
@@ -52,6 +53,7 @@ export const StepEditDialog: FC<StepDialogProps> = ({initialStep, handleClose, h
   const [location, setLocation] = React.useState<Well | undefined>(initialStep?.location)
   const [volume, setVolume] = React.useState<number>(initialStep?.volume ?? 0)
   const [touchtip, setTouchTip] = React.useState<boolean>(initialStep?.touchtip ?? true)
+  const [airgap, setAirgap] = React.useState<number>(initialStep?.airgap ?? 0)
   const [blowout, setBlowout] = React.useState<boolean>(initialStep?.blowout ?? false)
   const [blowoutLocation, setBlowoutLocation] = React.useState<string>(initialStep?.blowoutLocation ?? "trash")
   const [times, setTimes] = React.useState<number>(initialStep?.times ?? 0)
@@ -100,6 +102,11 @@ export const StepEditDialog: FC<StepDialogProps> = ({initialStep, handleClose, h
           setTouchTip(Boolean(e.target.checked))
         }} checked={touchtip}/>} label="Touch Tip"/>)}
 
+        {stepTypeHas(initialStep?.type, "airgap") ? <TextField type="number" onChange={(e) => {
+          e.persist();
+          setAirgap(Number(e.target.value))
+        }} id="outlined-basic" label="Airgap after Aspirate" variant="outlined" value={(airgap === 0) ? "" : airgap}/> : ''}
+
         <Grid container spacing={2}>
           <Grid item xs>
             {(initialStep?.blowout === false || initialStep?.blowout === true) && (<FormControlLabel control={<Checkbox onChange={(e) => {
@@ -129,11 +136,11 @@ export const StepEditDialog: FC<StepDialogProps> = ({initialStep, handleClose, h
           setTimes(Number(e.target.value))
         }} id="outlined-basic" label="Times to mix" variant="outlined" value={(times === 0) ? "" : times}/>}
 
-        {initialStep?.heightOfAgar && <TextField type="number" onChange={(e) => {
+        {stepTypeHas(initialStep?.type, "heightOfAgar") ? <TextField type="number" onChange={(e) => {
           e.persist();
           setHeightOfAgar(Number(e.target.value))
         }} id="outlined-basic" label="Height of Agar [mm]" variant="outlined"
-                                                                    value={(heightOfAgar === 0) ? "" : heightOfAgar}/>}
+                                                                    value={(heightOfAgar === 0) ? "" : heightOfAgar}/> : ''}
 
         {initialStep?.duration && <TextField type="number" onChange={(e) => {
           e.persist();
@@ -166,10 +173,15 @@ export const StepEditDialog: FC<StepDialogProps> = ({initialStep, handleClose, h
             initialStep.from = from
           }
           if (initialStep?.volume) {
-            initialStep.volume = volume
+            if (volume !== 0) {
+              initialStep.volume = volume
+            }
           }
           if (initialStep?.touchtip === false || initialStep?.touchtip === true) {
             initialStep.touchtip = touchtip
+          }
+          if (initialStep?.airgap) {
+            initialStep.airgap = airgap
           }
           if (initialStep?.blowout === false || initialStep?.blowout === true) {
             initialStep.blowout = blowout
@@ -181,13 +193,17 @@ export const StepEditDialog: FC<StepDialogProps> = ({initialStep, handleClose, h
             initialStep.location = location
           }
           if (initialStep?.duration) {
-            initialStep.duration = duration
+            if (duration !== 0) {
+              initialStep.duration = duration
+            }
           }
           if (initialStep?.times) {
             initialStep.times = times
           }
           if (initialStep?.heightOfAgar) {
-            initialStep.heightOfAgar = heightOfAgar
+            if (heightOfAgar !== 0) {
+              initialStep.heightOfAgar = heightOfAgar
+            }
           }
           if (initialStep?.sterility) {
             initialStep.sterility = sterility

--- a/src/components/dialogs/StepEditDialog.tsx
+++ b/src/components/dialogs/StepEditDialog.tsx
@@ -172,7 +172,7 @@ export const StepEditDialog: FC<StepDialogProps> = ({initialStep, handleClose, h
           if (initialStep?.from) {
             initialStep.from = from
           }
-          if (initialStep?.volume) {
+          if (stepTypeHas(initialStep?.type, "volume")) {
             if (volume !== 0) {
               initialStep.volume = volume
             }
@@ -180,7 +180,7 @@ export const StepEditDialog: FC<StepDialogProps> = ({initialStep, handleClose, h
           if (initialStep?.touchtip === false || initialStep?.touchtip === true) {
             initialStep.touchtip = touchtip
           }
-          if (initialStep?.airgap) {
+          if (stepTypeHas(initialStep?.type, "airgap")) {
             initialStep.airgap = airgap
           }
           if (initialStep?.blowout === false || initialStep?.blowout === true) {
@@ -200,7 +200,7 @@ export const StepEditDialog: FC<StepDialogProps> = ({initialStep, handleClose, h
           if (initialStep?.times) {
             initialStep.times = times
           }
-          if (initialStep?.heightOfAgar) {
+          if (stepTypeHas(initialStep?.type, "heightOfAgar")) {
             if (heightOfAgar !== 0) {
               initialStep.heightOfAgar = heightOfAgar
             }

--- a/src/components/dialogs/StepNewDialog.tsx
+++ b/src/components/dialogs/StepNewDialog.tsx
@@ -82,6 +82,7 @@ export const StepNewDialog: FC<StepNewDialogProps> = ({handleClose, handleSave, 
   const [location, setLocation] = React.useState<Well | undefined>()
   const [volume, setVolume] = React.useState<number>(0)
   const [touchtip, setTouchTip] = React.useState<boolean>(true)
+  const [airgap, setAirgap] = React.useState<number>(0)
   const [blowout, setBlowout] = React.useState<boolean>(false)
   const [blowoutLocation, setBlowoutLocation] = React.useState<string>("trash")
   const [times, setTimes] = React.useState<number>(0)
@@ -133,6 +134,11 @@ export const StepNewDialog: FC<StepNewDialogProps> = ({handleClose, handleSave, 
                 e.persist();
                 setTouchTip(Boolean(e.target.checked))
               }} checked={touchtip}/>} label="Touch Tip"/>)}
+              
+              {stepTypeHas(currentStepType, "airgap") && <TextField type="number" onChange={(e) => {
+                e.persist();
+                setAirgap(Number(e.target.value))
+              }} id="outlined-basic" label="Airgap after Aspirate" variant="outlined" value={(airgap === 0) ? "" : airgap}/>}
 
               <Grid container spacing={2}>
                 <Grid item xs>
@@ -202,7 +208,7 @@ export const StepNewDialog: FC<StepNewDialogProps> = ({handleClose, handleSave, 
           switch (currentStepType) {
             case StepType.TRANSFER:
               if (from && to && volume) {
-                step = new Transfer({from, to, volume, touchtip, blowout, blowoutLocation, sterility})
+                step = new Transfer({from, to, volume, touchtip, airgap, blowout, blowoutLocation, sterility})
               }
               break;
             case StepType.LASER:
@@ -227,7 +233,7 @@ export const StepNewDialog: FC<StepNewDialogProps> = ({handleClose, handleSave, 
               break;
             case StepType.PLATE:
               if (from && volume && heightOfAgar && to) {
-                step = new Plate({from, to, volume, touchtip, heightOfAgar, blowout, blowoutLocation})
+                step = new Plate({from, to, volume, touchtip, airgap, heightOfAgar, blowout, blowoutLocation})
               }
               break;
             case StepType.WAIT:

--- a/src/components/dialogs/StepNewDialog.tsx
+++ b/src/components/dialogs/StepNewDialog.tsx
@@ -125,7 +125,7 @@ export const StepNewDialog: FC<StepNewDialogProps> = ({handleClose, handleSave, 
                           well={location}
                           hide={!stepTypeHas(currentStepType, "location")}
               />
-              {stepTypeHas(currentStepType, "volume") && <TextField type="number" onChange={(e) => {
+              {stepTypeHas(currentStepType, "volume") && <TextField required type="number" onChange={(e) => {
                 e.persist();
                 setVolume(Number(e.target.value))
               }} id="outlined-basic" label="Volume [µL]" variant="outlined" value={(volume === 0) ? "" : volume}/>}
@@ -164,18 +164,18 @@ export const StepNewDialog: FC<StepNewDialogProps> = ({handleClose, handleSave, 
                 </Grid>
               </Grid>
 
-              {stepTypeHas(currentStepType, "times") && <TextField type="number" onChange={(e) => {
+              {stepTypeHas(currentStepType, "times") && <TextField required type="number" onChange={(e) => {
                 e.persist();
                 setTimes(Number(e.target.value))
               }} id="outlined-basic" label="Times to mix" variant="outlined" value={(times === 0) ? "" : times}/>}
 
-              {stepTypeHas(currentStepType, "heightOfAgar") && <TextField type="number" onChange={(e) => {
+              {stepTypeHas(currentStepType, "heightOfAgar") && <TextField required type="number" onChange={(e) => {
                 e.persist();
                 setHeightOfAgar(Number(e.target.value))
               }} id="outlined-basic" label="Height of Agar [mm]" variant="outlined"
                                                                           value={(heightOfAgar === 0) ? "" : heightOfAgar}/>}
 
-              {stepTypeHas(currentStepType, "duration") && <TextField type="number" onChange={(e) => {
+              {stepTypeHas(currentStepType, "duration") && <TextField required type="number" onChange={(e) => {
                 e.persist();
                 setDuration(Number(e.target.value))
               }} id="outlined-basic" label="Duration [sec]" variant="outlined"


### PR DESCRIPTION
- Adds a new input to the TRANSFER and PLATE steps called airgap which aspirates air into the pipette after the liquid. (Closes #16)
- Closes #17 by not saving required values if they are set to zero.
- Closes #18 by changing the render arguments to be based on the results of stepTypeHas() and not the value of the input option.